### PR TITLE
fix typo on test from Anagram to EmailAddressParser

### DIFF
--- a/lib/testing/email_address_parser_test.py
+++ b/lib/testing/email_address_parser_test.py
@@ -1,7 +1,7 @@
 from email_address_parser import EmailAddressParser
 
-class TestAnagram:
-    '''Class Anagram in anagram.py'''
+class TestEmailAddressParser:
+    '''Class EmailAddressParser in email_address_parser.py'''
 
     def test_instantiates_with_string(self):
         '''instantiates with a single argument, a string.'''


### PR DESCRIPTION
Currently the test suite for EmailAddressParser describes test for an Anagram class. Looks like a copy-paste error form another test suite, but let me know if that is not the case!

I changed Anagram and the file to point to the EmailAddressParser class and file instead.

Let me know if you have any questions or need anything change before this can be merged. Thank you!